### PR TITLE
Improve Docker setup and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,24 @@ FROM ghcr.io/berriai/litellm-database:main-latest
 # Set the working directory to /app
 WORKDIR /app
 
-# Copy the configuration file into the container at /app
-COPY config.yml .
+# Create a non-root user and group
+RUN groupadd -r litellm_group && useradd -r -g litellm_group -d /home/litellm_user -s /sbin/nologin litellm_user
 
-# Make sure your docker/entrypoint.sh is executable
-# RUN chmod +x entrypoint.sh
+# Create /app directory if it doesn't exist and set ownership
+RUN mkdir -p /app && chown -R litellm_user:litellm_group /app
+
+# Copy the configuration file into the container at /app
+COPY --chown=litellm_user:litellm_group config.yml .
 
 # Expose the necessary port
 EXPOSE 4000/tcp
+
+# Switch to the non-root user
+USER litellm_user
+
+# The default CMD includes --detailed_debug for development.
+# For production, it is recommended to use the command without --detailed_debug:
+# CMD ["--port", "4000", "--config", "config.yml"]
 
 # Override the CMD instruction with your desired command and arguments
 # WARNING: FOR PROD DO NOT USE `--detailed_debug` it slows down response times, instead use the following CMD

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
     openwebui:
-        image: ghcr.io/open-webui/open-webui:main
+        # Using a specific tag for Open WebUI for better stability. Check for newer versions on https://github.com/open-webui/open-webui/releases
+        image: ghcr.io/open-webui/open-webui:v0.6.10
         container_name: open-webui
         ports:
             - "3000:8080"
@@ -15,6 +16,7 @@ services:
         restart: always
 
     litellm:
+        # main-latest tracks recent changes. For critical production, consider finding and using a specific SHA digest or tagged release if available.
         image: ghcr.io/berriai/litellm-database:main-latest
         container_name: litellm
         env_file:
@@ -30,12 +32,13 @@ services:
             STORE_MODEL_IN_DB: "True"
 
     db:
-        image: postgres
+        # Using a specific major version of Postgres (e.g., 16-alpine) is recommended for stability.
+        image: postgres:16-alpine
         restart: always
         environment:
             POSTGRES_DB: litellm
-            POSTGRES_USER: llmproxy
-            POSTGRES_PASSWORD: dbpassword9090
+            POSTGRES_USER: llmproxy # Consider changing for production and managing via .env
+            POSTGRES_PASSWORD: dbpassword9090 # Consider changing for production and managing via .env
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -d litellm -U llmproxy"]
             interval: 1s


### PR DESCRIPTION
This commit introduces several improvements to the Docker configuration and documentation:

Dockerfile:
- Add a non-root user (litellm_user) for the litellm service to enhance security.
- Remove commented-out entrypoint.sh line.
- Clarify CMD instructions for debug (default) vs. production.

docker-compose.yaml:
- Pin openwebui image to v0.6.10 for stability.
- Pin postgres image to 16-alpine for stability and smaller size.
- Add comments regarding image versioning strategy for litellm (main-latest).
- Add comments to default Postgres credentials, advising changes for production.

README.md:
- Remove "Home Assistant HACS version on the way" subtitle.
- Add introduction explaining Open WebUI and LiteLLM roles.
- Strengthen advice for MASTER_KEY generation.
- Add new "Service Configuration Details" section covering:
    - Dockerfile non-root user.
    - Dockerfile CMD differences (debug vs. production) and docker-compose command.
    - Image tagging strategies in docker-compose.yaml.
    - Note on LiteLLM Dockerfile base image stability.
- Add new "Resource Considerations" section.
- Add a text-based architecture diagram to "Services Architecture".
- Add note confirming .env is in .gitignore.
- Expand security considerations regarding default Postgres credentials.